### PR TITLE
Try a different Poke implementation

### DIFF
--- a/src/Data/Store/Impl.hs
+++ b/src/Data/Store/Impl.hs
@@ -22,7 +22,7 @@
 -- "Data.Store.TH" due to Template Haskell's stage restriction.
 module Data.Store.Impl where
 
-import           Control.Exception (Exception(..), throwIO)
+import           Control.Exception (Exception(..), throwIO, assert)
 import           Control.Exception (try)
 import           Control.Monad
 import qualified Control.Monad.Fail as Fail
@@ -87,9 +87,10 @@ class Store a where
 -- 'size'), and then uses 'poke' to fill it.
 encode :: Store a => a -> BS.ByteString
 encode x = BS.unsafeCreate
-    (getSize x)
-    (\p -> void (runPoke (poke x) p 0))
-    -- TODO: how about checking if the size is correct?
+    l
+    (\p -> do (offset, ()) <- (runPoke (poke x) p 0)
+              assert (offset == l) (return ()))
+  where l = getSize x
 
 -- | Decodes a value from a 'BS.ByteString'. Returns an exception if
 -- there's an error while decoding, or if decoding undershoots /


### PR DESCRIPTION
This addresses #7.

Performance indeed seems to be improved. 

For example, for the benchmark `encode/10kb normal (Vector Int32)`, mean execution time goes down by roughly a quarter, from 112 microseconds to 81 microseconds.

For `encode/ ([SmallSumManual])`, it goes down by about 40%, from 330 ns to 191.

The instances derived from `Storable` do not seem to benefit, and neither does the encoding of single `Int`s. That's not really surprising, since in those cases, there's not a lot going on within `Poke`.
