### PR TITLE
Put warnings in docs for `hashOfType`.

### DIFF
--- a/src/Data/Store/TypeHash/Internal.hs
+++ b/src/Data/Store/TypeHash/Internal.hs
@@ -78,6 +78,12 @@ typeHashForNames ns = do
 -- including the definition of things it references (transitively).
 --
 -- The resulting expression is a literal of type 'Int'.
+--
+-- Note: this funtion will succeed silently even if the names present in the
+-- 'Type' cannot be found, which can happen if for example you do @hashOfType [t|Foo|]@
+-- with @Foo@ is defined in the same module. Thus, you should never use it,
+-- and instead use functions that output declarations such as 'mkHasTypeHash' and
+-- 'mkManyHasTypeHash'.
 hashOfType :: Type -> Q Exp
 hashOfType ty = do
     infos <- getTypeInfosRecursively (listify (\_ -> True) ty)


### PR DESCRIPTION
I was bitten and very confused by this.

CC @mgsloan 

I'm also a bit nervous that `reifyMany` silently recovers from failed `reify`s. What is the use case for that? In this case it seems a very dangerous feature.
