### PR TITLE
Use -N1, -s, and -qg for benchmarks.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -7,3 +7,4 @@ extra-deps:
 - th-lift-instances-0.1.6
 - th-utilities-0.1.0.0
 - th-reify-many-0.1.6
+- th-orphans-0.13.1

--- a/store.cabal
+++ b/store.cabal
@@ -121,7 +121,7 @@ benchmark store-bench
                      , binary
                      , binary-serialise-cbor
       cpp-options:     -DCOMPARISON_BENCH
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -fwarn-identities -O2
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N1 -with-rtsopts=-s -with-rtsopts=-qg -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -fwarn-identities -O2
   default-language:    Haskell2010
 
 source-repository head


### PR DESCRIPTION
This makes them much more stable and predictable.

Closed #13.

Also, added th-orphans-0.13.1 to stack.yaml.
