### PR TITLE
Check for correct size of messages.

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -82,8 +82,12 @@ library:
 
 tests:
   store-test:
-    source-dirs: test
+    source-dirs:
+      - test
+      - src
     main: Spec.hs
+    other-modules:
+      - Data.Store.Impl
     ghc-options: -threaded -rtsopts -with-rtsopts=-N
     dependencies:
       - store

--- a/src/Data/Store/Impl.hs
+++ b/src/Data/Store/Impl.hs
@@ -183,9 +183,8 @@ decodeIOPortionWith mypeek (BS.PS x s len) =
 decodeIOWithFromPtr :: Peek a -> Ptr Word8 -> Int -> IO a
 decodeIOWithFromPtr mypeek ptr len = do
     (offset, x) <- decodeIOPortionWithFromPtr mypeek ptr len
-    let remaining = len - offset
-    if remaining > 0
-       then throwIO $ PeekException remaining "Didn't consume all input."
+    if len /= offset
+       then throwIO $ PeekException (len - offset) "Didn't consume all input."
        else return x
 {-# INLINE decodeIOWithFromPtr #-}
 

--- a/src/Data/Store/Impl.hs
+++ b/src/Data/Store/Impl.hs
@@ -165,12 +165,10 @@ decodeIO = decodeIOWith peek
 -- exceptions, and taking a 'Peek' to run. It is an exception to not
 -- consume all input.
 decodeIOWith :: Peek a -> BS.ByteString -> IO a
-decodeIOWith mypeek bs = do
-    (offset, x) <- decodeIOPortionWith mypeek bs
-    let remaining = BS.length bs - offset
-    if remaining > 0
-        then throwIO $ PeekException remaining "Didn't consume all input."
-        else return x
+decodeIOWith mypeek (BS.PS x s len) =
+    withForeignPtr x $ \ptr0 ->
+        let ptr = ptr0 `plusPtr` s
+        in decodeIOWithFromPtr mypeek ptr len
 {-# INLINE decodeIOWith #-}
 
 -- | Similar to 'decodeExPortionWith', but runs in the 'IO' monad.
@@ -178,13 +176,30 @@ decodeIOPortionWith :: Peek a -> BS.ByteString -> IO (Offset, a)
 decodeIOPortionWith mypeek (BS.PS x s len) =
     withForeignPtr x $ \ptr0 ->
         let ptr = ptr0 `plusPtr` s
-            end = ptr `plusPtr` len
-         in do
-             (ptr2, x') <- runPeek mypeek end ptr
-             if ptr2 > end
-                 then throwIO $ PeekException (end `minusPtr` ptr2) "Overshot end of buffer"
-                 else return (ptr2 `minusPtr` ptr, x')
+        in decodeIOPortionWithFromPtr mypeek ptr len
 {-# INLINE decodeIOPortionWith #-}
+
+-- | Like 'decodeIOWith', but using 'Ptr' and length instead of a 'ByteString'.
+decodeIOWithFromPtr :: Peek a -> Ptr Word8 -> Int -> IO a
+decodeIOWithFromPtr mypeek ptr len = do
+    (offset, x) <- decodeIOPortionWithFromPtr mypeek ptr len
+    let remaining = len - offset
+    if remaining > 0
+       then throwIO $ PeekException remaining "Didn't consume all input."
+       else return x
+{-# INLINE decodeIOWithFromPtr #-}
+
+-- | Like 'decodeIOPortionWith', but using 'Ptr' and length instead of a 'ByteString'.
+decodeIOPortionWithFromPtr :: Peek a -> Ptr Word8 -> Int -> IO (Offset, a)
+decodeIOPortionWithFromPtr mypeek ptr len =
+    let end = ptr `plusPtr` len
+    in do
+        (ptr2, x') <- runPeek mypeek end ptr
+        if ptr2 > end
+            then throwIO $ PeekException (end `minusPtr` ptr2) "Overshot end of buffer"
+            else return (ptr2 `minusPtr` ptr, x')
+{-# INLINE decodeIOPortionWithFromPtr #-}
+
 
 ------------------------------------------------------------------------
 -- Generics

--- a/src/Data/Store/Streaming.hs
+++ b/src/Data/Store/Streaming.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-|
 Module: Data.Store.Streaming
 Description: A thin streaming layer that uses 'Store' for serialisation.
@@ -28,7 +29,7 @@ module Data.Store.Streaming
        , conduitDecode
        ) where
 
-import           Control.Exception (assert)
+import           Control.Exception (assert, throwIO)
 import           Control.Monad (liftM)
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Resource (MonadResource)
@@ -143,8 +144,14 @@ decodeSized bb getBs n =
 -- | Decode a value, given a 'Ptr' and the number of bytes that make
 -- up the encoded message.
 decodeFromPtr :: (MonadIO m, Store a) => Ptr Word8 -> Int -> m a
-decodeFromPtr ptr n =
-    liftIO (liftM snd $ runPeek peek (ptr `plusPtr` n) ptr)
+decodeFromPtr ptr n = liftIO $ do
+    (ptr2, x) <- runPeek peek end ptr
+    case ptr2 `compare` end
+      of EQ -> return x
+         GT -> throwIO $ PeekException (ptr2 `minusPtr` end) "Consumed more input than anticipated."
+         LT -> throwIO $ PeekException (end `minusPtr` ptr2) "Consumed less input than anticipated."
+  where
+    end = ptr `plusPtr` n
 {-# INLINE decodeFromPtr #-}
 
 -- | Conduit for encoding 'Message's to 'ByteString's.

--- a/store.cabal
+++ b/store.cabal
@@ -91,6 +91,7 @@ test-suite store-test
   main-is: Spec.hs
   hs-source-dirs:
       test
+    , src
   ghc-options: -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -O2 -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
@@ -130,11 +131,7 @@ test-suite store-test
     , void >=0.5.11
     , store
   other-modules:
-      Allocations
-      Data.Store.StreamingSpec
-      Data.StoreSpec
-      Data.StoreSpec.TH
-      System.IO.ByteBufferSpec
+      Data.Store.Impl
   default-language: Haskell2010
 
 test-suite store-weigh

--- a/test/Data/Store/StreamingSpec.hs
+++ b/test/Data/Store/StreamingSpec.hs
@@ -2,14 +2,18 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Data.Store.StreamingSpec where
 
+import Control.Monad (void)
+import           Control.Exception (try)
 import           Control.Monad.Trans.Resource
-import Control.Exception (try)
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Internal as BS
 import           Data.Conduit ((=$=), ($$))
 import qualified Data.Conduit.List as C
+import           Data.Int
 import           Data.List (unfoldr)
 import           Data.Monoid
-import           Data.Store (PeekException (..))
+import           Data.Store.Impl (Poke (..))
+import           Data.Store.Internal -- (PeekException (..))
 import           Data.Store.Streaming
 import qualified System.IO.ByteBuffer as BB
 import           Test.Hspec
@@ -26,9 +30,11 @@ spec = do
   describe "peekMessage" $ do
     it "demands more input when needed." $ property (askMore 8)
     it "demands more input on incomplete SizeTag." $ property (askMore 1)
-    it "successfully decodes valid input." $ property peek
-  describe "decodeMessage" $
+    it "successfully decodes valid input." $ property canPeek
+  describe "decodeMessage" $ do
     it "Throws an Exception on incomplete messages." decodeIncomplete
+    it "Throws an Exception on messages that are shorter than indicated." decodeTooShort
+    it "Throws an Exception on messages that are longer than indicated." decodeTooLong
 
 roundtrip :: [Int] -> Property IO
 roundtrip xs = monadic $ do
@@ -65,7 +71,7 @@ conduitIncomplete =
     (runResourceT (C.sourceList [incompleteInput]
                   =$= conduitDecode (Just 10)
                   $$ C.consume)
-    :: IO [Message Integer]) `shouldThrow` peekException
+    :: IO [Message Integer]) `shouldThrow` isPeekException
 
 conduitExcess :: [Int] -> Property IO
 conduitExcess xs = monadic $ do
@@ -97,8 +103,8 @@ askMore n x = monadic $ BB.with (Just 10) $ \ bb -> do
         _ -> return False
     _ -> return False
 
-peek :: Integer -> Property IO
-peek x = monadic $ BB.with (Just 10) $ \ bb -> do
+canPeek :: Integer -> Property IO
+canPeek x = monadic $ BB.with (Just 10) $ \ bb -> do
   let bs = encodeMessage (Message x)
   BB.copyByteString bb bs
   peekResult <- peekMessage bb :: IO (PeekMessage IO Integer)
@@ -110,12 +116,40 @@ decodeIncomplete :: IO ()
 decodeIncomplete = BB.with (Just 0) $ \ bb -> do
   BB.copyByteString bb (BS.take 1 incompleteInput)
   (decodeMessage bb (return Nothing) :: IO (Maybe (Message Integer)))
-    `shouldThrow` peekException
+    `shouldThrow` isPeekException
 
 incompleteInput :: BS.ByteString
 incompleteInput =
   let bs = encodeMessage (Message (42 :: Integer))
   in BS.take (BS.length bs - 1) bs
 
-peekException :: Selector PeekException
-peekException = const True
+isPeekException :: Selector PeekException
+isPeekException = const True
+
+decodeTooLong :: IO ()
+decodeTooLong = BB.with Nothing $ \bb -> do
+    BB.copyByteString bb (encodeMessageTooLong . Message $ (1 :: Int))
+    (decodeMessage bb (return Nothing) :: IO (Maybe (Message Int)))
+        `shouldThrow` isPeekException
+
+decodeTooShort :: IO ()
+decodeTooShort = BB.with Nothing $ \bb -> do
+    BB.copyByteString bb (encodeMessageTooShort . Message $ (1 :: Int))
+    (decodeMessage bb (return Nothing) :: IO (Maybe (Message Int)))
+        `shouldThrow` isPeekException
+
+encodeMessageTooLong :: Store a => Message a -> BS.ByteString
+encodeMessageTooLong (Message x) =
+    let l = 8 + getSize x
+        totalLength = 8 + l
+    in BS.unsafeCreate
+       totalLength
+       (\p -> void $ runPoke (poke l >> poke x >> poke (0::Int64)) p 0)
+
+encodeMessageTooShort :: Store a => Message a -> BS.ByteString
+encodeMessageTooShort (Message x) =
+    let l = 0
+        totalLength = 8 + l
+    in BS.unsafeCreate
+       totalLength
+       (\p -> void $ runPoke (poke l >> poke x) p 0)


### PR DESCRIPTION
The code for decoding streaming messages was lacking the checks that make sure that all input is consumed. This pr fixes that, and unifies the code for decoding in the streaming and non-streaming layer.