### PR TITLE
Export GStoreSize, GStorePoke, GStorePeek from Data.Store.Internal

### DIFF
--- a/src/Data/Store/Internal.hs
+++ b/src/Data/Store/Internal.hs
@@ -49,7 +49,9 @@ module Data.Store.Internal
     -- ** Store instances in terms of IArray
     , sizeArray, pokeArray, peekArray
     -- ** Store instances in terms of Generic
-    , genericSize, genericPoke, genericPeek
+    , GStoreSize, genericSize
+    , GStorePoke, genericPoke
+    , GStorePeek, genericPeek
     -- ** Peek utilities
     , skip, isolate
     -- ** Static Size type


### PR DESCRIPTION
These constraints are propagated when using `genericSize`, `genericPoke` and `genericPeek` directly, yet they can't be mentioned because they are not exported. 