### PR TITLE
Fix the tests on 32bit systems.

### DIFF
--- a/src/Data/Store/Streaming.hs
+++ b/src/Data/Store/Streaming.hs
@@ -21,6 +21,7 @@ Each message starts with a fixed magic number, in order to detect
 module Data.Store.Streaming
        ( -- * 'Message's to stream data using 'Store' for serialisation.
          Message (..)
+       , headerLength
          -- * Encoding 'Message's
        , encodeMessage
          -- * Decoding 'Message's
@@ -68,6 +69,7 @@ magicLength = Storable.sizeOf messageMagic
 sizeTagLength :: Int
 sizeTagLength = Storable.sizeOf (undefined :: SizeTag)
 
+-- | Number of bytes needed for the magic number and size tag.
 headerLength :: Int
 headerLength = magicLength + sizeTagLength
 


### PR DESCRIPTION
The tests for the streaming interface failed on 32bit systems, because
they made assumptions about the size of the message headers that are
only true on 64 bit architectures.