### PR TITLE
Fix bounds checks.

### DIFF
--- a/src/Data/Store/Internal.hs
+++ b/src/Data/Store/Internal.hs
@@ -275,8 +275,9 @@ peekMutableSequence new write = do
 skip :: Int -> Peek ()
 skip len = Peek $ \end ptr -> do
     let ptr2 = ptr `plusPtr` len
-    when (ptr2 > end) $
-        tooManyBytes len (end `minusPtr` ptr) "skip"
+        remaining = end `minusPtr` ptr
+    when (len > remaining) $
+        tooManyBytes len remaining "skip"
     return (ptr2, ())
 
 -- | Isolate the input to n bytes, skipping n bytes forward. Fails if @m@
@@ -285,8 +286,9 @@ skip len = Peek $ \end ptr -> do
 isolate :: Int -> Peek a -> Peek a
 isolate len m = Peek $ \end ptr -> do
     let ptr2 = ptr `plusPtr` len
-    when (ptr2 > end) $
-        tooManyBytes len (end `minusPtr` ptr) "isolate"
+        remaining = end `minusPtr` ptr
+    when (len > remaining) $
+        tooManyBytes len remaining "isolate"
     (ptr', x) <- runPeek m end ptr
     when (ptr' > end) $
         throwIO $ PeekException (ptr' `minusPtr` end) "Overshot end of isolated bytes"


### PR DESCRIPTION
They were susceptible to overflows when trying to read data of verly
large length (which can happen with corrupt data).

Closed #70.