### PR TITLE
Use a scratch buffer to work around alignment #37

### DIFF
--- a/store-core/package.yaml
+++ b/store-core/package.yaml
@@ -9,6 +9,11 @@ category: Serialization, Data
 extra-source-files:
   - ChangeLog.md
 
+flags:
+  force-alignment:
+    default: false
+    manual: true
+
 ghc-options: -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -O2
 
 dependencies:
@@ -23,7 +28,9 @@ dependencies:
 library:
   source-dirs: src
   when:
-    # Theoretically, these are the architectures which support reasonably
-    # efficient unaligned access.
-    - condition: (!arch(I386) && !arch(X86_64) && !arch(IA64) && !impl(ghcjs) && !impl(AArch64))
+    - condition: (!arch(I386) && !arch(X86_64) && !arch(IA64) && !impl(ghcjs) && !arch(AArch64) && !arch(PPC) && !arch(PPC64) && !arch(Mips) && !arch(Sparc))
       buildable: false
+
+when:
+  - condition: flag(force-alignment) || arch(PPC) || arch(PPC64) || arch(Mips) || arch(Sparc)
+    cpp-options: -DALIGNED_MEMORY

--- a/store-core/store-core.cabal
+++ b/store-core/store-core.cabal
@@ -22,6 +22,10 @@ source-repository head
   type: git
   location: https://github.com/fpco/store
 
+flag force-alignment
+  manual: True
+  default: False
+
 library
   hs-source-dirs:
       src
@@ -34,7 +38,9 @@ library
     , transformers >=0.3.0.0 && < 1.0
     , ghc-prim >=0.3.1.0 && < 1.0
     , text >=1.2.0.4 && < 2.0
-  if (!arch(I386) && !arch(X86_64) && !arch(IA64) && !impl(ghcjs) && !impl(AArch64))
+  if flag(force-alignment) || arch(PPC) || arch(PPC64) || arch(Mips) || arch(Sparc)
+    cpp-options: -DALIGNED_MEMORY
+  if (!arch(I386) && !arch(X86_64) && !arch(IA64) && !impl(ghcjs) && !arch(AArch64) && !arch(PPC) && !arch(PPC64) && !arch(Mips) && !arch(Sparc))
     buildable: False
   exposed-modules:
       Data.Store.Core


### PR DESCRIPTION
Here's how this works:

* When encoding is done on an architecture that has alignment constraints, it first allocates a 128 byte buffer

* When an unaligned peek or poke needs to happen, the bytes are copied to / from the buffer.

* If more than 128 bytes are needed for a `Storable`, a new buffer is allocated temporarily.

Open questions:

1) Maybe it should delay allocating the buffer until the first time a Storable needs to be serialized?  Could also default to being some more reasonably sized buffer, by always just growing it as needed.

2) Is 128 bytes a reasonable default size?  Anything bigger will require a new allocation.  On the other hand, most uses of `Storable` are for things with a small size.

Pinging @dysinger for review, as it would be cool to see if this makes stack work on ARM again.