### PR TITLE
Remove `fail` dependency in `store.cabal` also

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -49,7 +49,6 @@ dependencies:
   - cryptohash >=0.11.6
   - deepseq >=1.3.0.2
   - directory >= 1.2
-  - fail >=4.9.0.0
   - filepath >= 1.3
   - ghc-prim >=0.3.1.0
   - hashable >=1.2.3.1

--- a/store.cabal
+++ b/store.cabal
@@ -61,7 +61,6 @@ library
     , cryptohash >=0.11.6
     , deepseq >=1.3.0.2
     , directory >= 1.2
-    , fail >=4.9.0.0
     , filepath >= 1.3
     , ghc-prim >=0.3.1.0
     , hashable >=1.2.3.1
@@ -110,7 +109,6 @@ test-suite store-test
     , cryptohash >=0.11.6
     , deepseq >=1.3.0.2
     , directory >= 1.2
-    , fail >=4.9.0.0
     , filepath >= 1.3
     , ghc-prim >=0.3.1.0
     , hashable >=1.2.3.1
@@ -164,7 +162,6 @@ test-suite store-weigh
     , cryptohash >=0.11.6
     , deepseq >=1.3.0.2
     , directory >= 1.2
-    , fail >=4.9.0.0
     , filepath >= 1.3
     , ghc-prim >=0.3.1.0
     , hashable >=1.2.3.1
@@ -224,7 +221,6 @@ benchmark store-bench
     , cryptohash >=0.11.6
     , deepseq >=1.3.0.2
     , directory >= 1.2
-    , fail >=4.9.0.0
     , filepath >= 1.3
     , ghc-prim >=0.3.1.0
     , hashable >=1.2.3.1


### PR DESCRIPTION
Somehow I had forgotten to include this in the other commit.