### PR TITLE
Invalidate ByteBuffers on Exceptions.

### DIFF
--- a/src/System/IO/ByteBuffer.hs
+++ b/src/System/IO/ByteBuffer.hs
@@ -136,9 +136,10 @@ bbHandler ::
     -> IO a
 bbHandler loc bb e = do
     readIORef bb >>= \case
-        Right bbref -> Alloc.free (ptr bbref)
+        Right bbref -> do
+            Alloc.free (ptr bbref)
+            writeIORef bb (Left $ ByteBufferException loc (show e))
         Left _ -> return ()
-    writeIORef bb (Left $ ByteBufferException loc (show e))
     throwIO e
 
 -- | Try to use the 'BBRef' of a 'ByteBuffer', or throw a 'ByteBufferException' if it's invalid.

--- a/src/System/IO/ByteBuffer.hs
+++ b/src/System/IO/ByteBuffer.hs
@@ -1,5 +1,6 @@
 {-@ LIQUID "--no-termination" @-}
 {-@ LIQUID "--short-names"    @-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -222,7 +223,7 @@ resetBBRef bbref = do
 -- bytes long.
 {-@ enlargeBBRef :: b:BBRef -> i:Nat -> IO {v:BBRef | size v >= i && contained v == contained b && consumed v == consumed b} @-}
 enlargeBBRef :: BBRef -> Int -> IO BBRef
-enlargeBBRef bbref minSize= do
+enlargeBBRef bbref minSize = do
         let getNewSize s | s >= minSize = s
             getNewSize s = getNewSize $ (ceiling . (*(1.5 :: Double)) . fromIntegral) (max 1 s)
             newSize = getNewSize (size bbref)


### PR DESCRIPTION
When an Exception is encountered while modifying a ByteBuffer, it is
invalidated.  This ensures that ByteBuffers that might be corrupted are
not used subsequently.

ByteBuffers are also invalidated when they are explicitly freed.