### PR TITLE
Use 'fromDistinctAscList' to peek containers

### DIFF
--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -13,6 +13,10 @@ import           Control.DeepSeq
 import           Criterion.Main
 import qualified Data.ByteString as BS
 import           Data.Int
+import qualified Data.IntMap.Strict as IntMap
+import qualified Data.IntSet as IntSet
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import           Data.Store
 import           Data.Typeable
 import qualified Data.Vector as V
@@ -71,6 +75,16 @@ main = do
                        _ -> error "This does not compute."
                ) <$> V.enumFromTo 1 (100 :: Int)
         nestedTuples = (\i -> ((i,i+1),(i+2,i+3))) <$> V.enumFromTo (1::Int) 100
+
+        ints = [1..100] :: [Int]
+        pairs = map (\x -> (x, x)) ints
+        strings = show <$> ints
+        intsSet = Set.fromDistinctAscList ints
+        intSet = IntSet.fromDistinctAscList ints
+        intsMap = Map.fromDistinctAscList pairs
+        intMap = IntMap.fromDistinctAscList pairs
+        stringsSet = Set.fromList strings
+        stringsMap = Map.fromList (zip strings ints)
 #endif
     defaultMain
         [ bgroup "encode"
@@ -80,6 +94,12 @@ main = do
             , benchEncode' "10kb storable" (SV.fromList ([1..(256 * 10)] :: [Int32]))
             , benchEncode' "1kb normal" (V.fromList ([1..256] :: [Int32]))
             , benchEncode' "10kb normal" (V.fromList ([1..(256 * 10)] :: [Int32]))
+            , benchEncode intsSet
+            , benchEncode intSet
+            , benchEncode intsMap
+            , benchEncode intMap
+            , benchEncode stringsSet
+            , benchEncode stringsMap
 #endif
             , benchEncode smallprods
             , benchEncode smallmanualprods
@@ -95,6 +115,12 @@ main = do
             , benchDecode' "10kb storable" (SV.fromList ([1..(256 * 10)] :: [Int32]))
             , benchDecode' "1kb normal" (V.fromList ([1..256] :: [Int32]))
             , benchDecode' "10kb normal" (V.fromList ([1..(256 * 10)] :: [Int32]))
+            , benchDecode intsSet
+            , benchDecode intSet
+            , benchDecode intsMap
+            , benchDecode intMap
+            , benchDecode stringsSet
+            , benchDecode stringsMap
 #endif
             , benchDecode smallprods
             , benchDecode smallmanualprods

--- a/src/Data/Store/Internal.hs
+++ b/src/Data/Store/Internal.hs
@@ -81,9 +81,12 @@ import           Data.HashMap.Strict (HashMap)
 import           Data.HashSet (HashSet)
 import           Data.Hashable (Hashable)
 import           Data.IntMap (IntMap)
+import qualified Data.IntMap.Strict as IntMap
 import           Data.IntSet (IntSet)
+import qualified Data.IntSet as IntSet
 import qualified Data.List.NonEmpty as NE
 import           Data.Map (Map)
+import qualified Data.Map.Strict as Map
 import           Data.MonoTraversable
 import           Data.Monoid
 import           Data.Orphans ()
@@ -92,6 +95,7 @@ import           Data.Proxy (Proxy(..))
 import           Data.Sequence (Seq)
 import           Data.Sequences (IsSequence, Index, replicateM)
 import           Data.Set (Set)
+import qualified Data.Set as Set
 import           Data.Store.Impl
 import           Data.Store.Core
 import           Data.Store.TH.Internal
@@ -463,7 +467,7 @@ instance Store a => Store (Seq a) where
 instance (Store a, Ord a) => Store (Set a) where
     size = sizeSet
     poke = pokeSet
-    peek = peekSet
+    peek = Set.fromDistinctAscList <$> peek
     {-# INLINE size #-}
     {-# INLINE peek #-}
     {-# INLINE poke #-}
@@ -471,7 +475,7 @@ instance (Store a, Ord a) => Store (Set a) where
 instance Store IntSet where
     size = sizeSet
     poke = pokeSet
-    peek = peekSet
+    peek = IntSet.fromDistinctAscList <$> peek
     {-# INLINE size #-}
     {-# INLINE peek #-}
     {-# INLINE poke #-}
@@ -479,7 +483,7 @@ instance Store IntSet where
 instance Store a => Store (IntMap a) where
     size = sizeMap
     poke = pokeMap
-    peek = peekMap
+    peek = IntMap.fromDistinctAscList <$> peek
     {-# INLINE size #-}
     {-# INLINE peek #-}
     {-# INLINE poke #-}
@@ -487,7 +491,7 @@ instance Store a => Store (IntMap a) where
 instance (Ord k, Store k, Store a) => Store (Map k a) where
     size = sizeMap
     poke = pokeMap
-    peek = peekMap
+    peek = Map.fromDistinctAscList <$> peek
     {-# INLINE size #-}
     {-# INLINE peek #-}
     {-# INLINE poke #-}

--- a/test/Allocations.hs
+++ b/test/Allocations.hs
@@ -7,8 +7,11 @@
 module Main where
 
 import           Control.DeepSeq
-import           Data.List
+import qualified Data.IntMap.Strict as IntMap
+import qualified Data.IntSet as IntSet
 import qualified Data.Serialize as Cereal
+import qualified Data.Set as Set
+import qualified Data.Map.Strict as Map
 import qualified Data.Store as Store
 import qualified Data.Vector as Boxed
 import qualified Data.Vector.Serialize ()
@@ -19,26 +22,39 @@ import           Weigh
 -- | Main entry point.
 main :: IO ()
 main =
-  mainWith encoding
+  mainWith weighing
 
--- | Weigh encoding with Store vs Cereal.
-encoding :: Weigh ()
-encoding =
+-- | Weigh weighing with Store vs Cereal.
+weighing :: Weigh ()
+weighing =
   do fortype "[Int]" (\n -> replicate n 0 :: [Int])
      fortype "Boxed Vector Int" (\n -> Boxed.replicate n 0 :: Boxed.Vector Int)
      fortype "Storable Vector Int"
              (\n -> Storable.replicate n 0 :: Storable.Vector Int)
+     fortype "Set Int" (Set.fromDistinctAscList . ints)
+     fortype "IntSet" (IntSet.fromDistinctAscList . ints)
+     fortype "Map Int Int" (Map.fromDistinctAscList . intpairs)
+     fortype "IntMap Int" (IntMap.fromDistinctAscList . intpairs)
   where fortype label make =
           scale (\(n,nstr) ->
                    do let title :: String -> String
                           title for = printf "%12s %-20s %s" nstr (label :: String) for
+                          encodeDecode en de =
+                            (return . (`asTypeOf` make n) . de . force . en . make) n
                       action (title "Allocate")
                              (return (make n))
                       action (title "Encode: Store")
                              (return (Store.encode (force (make n))))
                       action (title "Encode: Cereal")
-                             (return (Cereal.encode (force (make n)))))
-        scale func =
-          mapM_ func
+                             (return (Cereal.encode (force (make n))))
+                      action (title "Encode/Decode: Store")
+                             (encodeDecode Store.encode Store.decodeEx)
+                      action (title "Encode/Decode: Cereal")
+                             (encodeDecode Cereal.encode (fromRight . Cereal.decode)))
+        scale f =
+          mapM_ f
                 (map (\x -> (x,commas x))
                      [1000000,2000000,10000000])
+        ints n = [1..n] :: [Int]
+        intpairs = map (\x -> (x, x)) . ints
+        fromRight = either (error "Left") id


### PR DESCRIPTION
Timings (compared with https://github.com/bgamari/criterion-compare):

![bench_diff](https://cloud.githubusercontent.com/assets/3664523/23054123/51a49770-f4de-11e6-80ce-976fd2de64b1.png)

Allocations:

```
50c50
<    1,000,000 Set Int              Encode/Decode: Store      420,580,976     759  OK   
---
>    1,000,000 Set Int              Encode/Decode: Store      424,580,960     766  OK   
55c55
<    2,000,000 Set Int              Encode/Decode: Store      841,194,352   1,518  OK   
---
>    2,000,000 Set Int              Encode/Decode: Store      849,194,336   1,533  OK   
60,61c60,61
<   10,000,000 Set Int              Encode/Decode: Store    4,206,073,136   7,592  OK   
---
>   10,000,000 Set Int              Encode/Decode: Store    4,246,073,120   7,666  OK   
65c65
<    1,000,000 IntSet               Encode/Decode: Store      549,981,224   1,006  OK   
---
>    1,000,000 IntSet               Encode/Decode: Store      252,081,288     435  OK   
70c70
<    2,000,000 IntSet               Encode/Decode: Store    1,139,994,280   2,088  OK   
---
>    2,000,000 IntSet               Encode/Decode: Store      504,194,664     871  OK   
75c75
<   10,000,000 IntSet               Encode/Decode: Store    6,123,454,160  11,252  OK   
---
>   10,000,000 IntSet               Encode/Decode: Store    2,521,068,904   4,355  OK   
80c80
<    1,000,000 Map Int Int          Encode/Decode: Store    1,864,730,336   3,513  OK   
---
>    1,000,000 Map Int Int          Encode/Decode: Store      576,580,912   1,045  OK   
85c85
<    2,000,000 Map Int Int          Encode/Decode: Store    3,873,491,728   7,306  OK   
---
>    2,000,000 Map Int Int          Encode/Decode: Store    1,153,194,288   2,091  OK   
90c90
<   10,000,000 Map Int Int          Encode/Decode: Store   21,013,631,392  39,721  OK   
---
>   10,000,000 Map Int Int          Encode/Decode: Store    5,766,073,968  10,456  OK   
95c95
<    1,000,000 IntMap Int           Encode/Decode: Store      940,404,992   1,742  OK   
---
>    1,000,000 IntMap Int           Encode/Decode: Store      608,581,080   1,106  OK   
100c100
<    2,000,000 IntMap Int           Encode/Decode: Store    1,920,843,976   3,560  OK   
---
>    2,000,000 IntMap Int           Encode/Decode: Store    1,217,194,456   2,212  OK   
105c105
<   10,000,000 IntMap Int           Encode/Decode: Store   10,254,619,488  19,050  OK   
---
>   10,000,000 IntMap Int           Encode/Decode: Store    6,086,072,536  11,064  OK   
```

There's this strange slowdown for `Set Int` but then folks should use `IntSet` anyway.