### PR TITLE
Faster 'size' for map and set

### DIFF
--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -13,6 +13,10 @@ import           Control.DeepSeq
 import           Criterion.Main
 import qualified Data.ByteString as BS
 import           Data.Int
+import qualified Data.IntMap.Strict as IntMap
+import qualified Data.IntSet as IntSet
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import           Data.Store
 import           Data.Typeable
 import qualified Data.Vector as V
@@ -71,6 +75,16 @@ main = do
                        _ -> error "This does not compute."
                ) <$> V.enumFromTo 1 (100 :: Int)
         nestedTuples = (\i -> ((i,i+1),(i+2,i+3))) <$> V.enumFromTo (1::Int) 100
+
+        ints = [1..100] :: [Int]
+        pairs = map (\x -> (x, x)) ints
+        strings = show <$> ints
+        intsSet = Set.fromDistinctAscList ints
+        intSet = IntSet.fromDistinctAscList ints
+        intsMap = Map.fromDistinctAscList pairs
+        intMap = IntMap.fromDistinctAscList pairs
+        stringsSet = Set.fromList strings
+        stringsMap = Map.fromList (zip strings ints)
 #endif
     defaultMain
         [ bgroup "encode"
@@ -80,6 +94,12 @@ main = do
             , benchEncode' "10kb storable" (SV.fromList ([1..(256 * 10)] :: [Int32]))
             , benchEncode' "1kb normal" (V.fromList ([1..256] :: [Int32]))
             , benchEncode' "10kb normal" (V.fromList ([1..(256 * 10)] :: [Int32]))
+            , benchEncode intsSet
+            , benchEncode intSet
+            , benchEncode intsMap
+            , benchEncode intMap
+            , benchEncode stringsSet
+            , benchEncode stringsMap
 #endif
             , benchEncode smallprods
             , benchEncode smallmanualprods
@@ -95,6 +115,12 @@ main = do
             , benchDecode' "10kb storable" (SV.fromList ([1..(256 * 10)] :: [Int32]))
             , benchDecode' "1kb normal" (V.fromList ([1..256] :: [Int32]))
             , benchDecode' "10kb normal" (V.fromList ([1..(256 * 10)] :: [Int32]))
+            , benchDecode intsSet
+            , benchDecode intSet
+            , benchDecode intsMap
+            , benchDecode intMap
+            , benchDecode stringsSet
+            , benchDecode stringsMap
 #endif
             , benchDecode smallprods
             , benchDecode smallmanualprods

--- a/test/Allocations.hs
+++ b/test/Allocations.hs
@@ -7,8 +7,11 @@
 module Main where
 
 import           Control.DeepSeq
-import           Data.List
+import qualified Data.IntMap.Strict as IntMap
+import qualified Data.IntSet as IntSet
 import qualified Data.Serialize as Cereal
+import qualified Data.Set as Set
+import qualified Data.Map.Strict as Map
 import qualified Data.Store as Store
 import qualified Data.Vector as Boxed
 import qualified Data.Vector.Serialize ()
@@ -19,26 +22,39 @@ import           Weigh
 -- | Main entry point.
 main :: IO ()
 main =
-  mainWith encoding
+  mainWith weighing
 
--- | Weigh encoding with Store vs Cereal.
-encoding :: Weigh ()
-encoding =
+-- | Weigh weighing with Store vs Cereal.
+weighing :: Weigh ()
+weighing =
   do fortype "[Int]" (\n -> replicate n 0 :: [Int])
      fortype "Boxed Vector Int" (\n -> Boxed.replicate n 0 :: Boxed.Vector Int)
      fortype "Storable Vector Int"
              (\n -> Storable.replicate n 0 :: Storable.Vector Int)
+     fortype "Set Int" (Set.fromDistinctAscList . ints)
+     fortype "IntSet" (IntSet.fromDistinctAscList . ints)
+     fortype "Map Int Int" (Map.fromDistinctAscList . intpairs)
+     fortype "IntMap Int" (IntMap.fromDistinctAscList . intpairs)
   where fortype label make =
           scale (\(n,nstr) ->
                    do let title :: String -> String
                           title for = printf "%12s %-20s %s" nstr (label :: String) for
+                          encodeDecode en de =
+                            (return . (`asTypeOf` make n) . de . force . en . make) n
                       action (title "Allocate")
                              (return (make n))
                       action (title "Encode: Store")
                              (return (Store.encode (force (make n))))
                       action (title "Encode: Cereal")
-                             (return (Cereal.encode (force (make n)))))
-        scale func =
-          mapM_ func
+                             (return (Cereal.encode (force (make n))))
+                      action (title "Encode/Decode: Store")
+                             (encodeDecode Store.encode Store.decodeEx)
+                      action (title "Encode/Decode: Cereal")
+                             (encodeDecode Cereal.encode (fromRight . Cereal.decode)))
+        scale f =
+          mapM_ f
                 (map (\x -> (x,commas x))
                      [1000000,2000000,10000000])
+        ints n = [1..n] :: [Int]
+        intpairs = map (\x -> (x, x)) . ints
+        fromRight = either (error "Left") id


### PR DESCRIPTION

![image](https://cloud.githubusercontent.com/assets/3664523/23188906/c9594d8c-f890-11e6-9c5c-9a4cc9d68f58.png)

A fix for `olength` [has been merged](https://github.com/snoyberg/mono-traversable/pull/125).