### PR TITLE
Add untrusted tests

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -89,6 +89,7 @@ tests:
     main: Spec.hs
     other-modules:
       - Data.Store.StreamingSpec
+      - Data.Store.UntrustedSpec
       - Data.StoreSpec
       - Data.StoreSpec.TH
       - System.IO.ByteBufferSpec

--- a/store.cabal
+++ b/store.cabal
@@ -147,6 +147,7 @@ test-suite store-test
     , store
   other-modules:
       Data.Store.StreamingSpec
+      Data.Store.UntrustedSpec
       Data.StoreSpec
       Data.StoreSpec.TH
       System.IO.ByteBufferSpec

--- a/store.cabal
+++ b/store.cabal
@@ -145,6 +145,7 @@ test-suite store-test
     , async >=2.0.2
     , contravariant >=1.3
     , store
+    , bifunctors
   other-modules:
       Data.Store.StreamingSpec
       Data.Store.UntrustedSpec

--- a/test/Data/Store/UntrustedSpec.hs
+++ b/test/Data/Store/UntrustedSpec.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Tests for untrusted data.
+
+module Data.Store.UntrustedSpec where
+
+import           Data.Bifunctor
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as S
+import qualified Data.ByteString.Lazy as L
+import           Data.Int
+import           Data.Monoid
+import           Data.Store
+import           Data.String
+import           Data.Text (Text)
+import qualified Data.Vector as V
+import           Test.Hspec
+
+-- | Test suite.
+spec :: Spec
+spec =
+    describe
+        "Untrusted input throws error"
+        (do describe
+                "Array-like length prefixes"
+                (do let sample
+                            :: IsString s
+                            => s
+                        sample = "abc"
+                        list :: [Int]
+                        list = [1, 2, 3]
+                    it
+                        "ByteString"
+                        (shouldBeRightWrong 1234 (sample :: ByteString))
+                    it
+                        "Lazy ByteString"
+                        (shouldBeRightWrong 1234 (sample :: L.ByteString))
+                    it "Text" (shouldBeRightWrong 1234 (sample :: Text))
+                    it "String" (shouldBeRightWrong 1234 (sample :: String))
+                    it "Vector Int" (shouldBeRightWrong 1234 (V.fromList list))
+                    it
+                        "Vector Char"
+                        (shouldBeRightWrong 1234 (V.fromList sample)))
+            describe
+                "Constructor tags"
+                (do it
+                        "Invalid constructor tag"
+                        (shouldBe
+                             (first
+                                  (const ())
+                                  (decode "\2" :: Either PeekException (Maybe ())))
+                             (Left ()))
+                    it
+                        "Missing slots"
+                        (shouldBe
+                             (first
+                                  (const ())
+                                  (decode "\1" :: Either PeekException (Maybe Char)))
+                             (Left ()))))
+
+-- | Check decode.encode==id and then check decode.badencode=>error.
+shouldBeRightWrong
+    :: forall i.
+       (Store i, Eq i, Show i)
+    => Int64 -> i -> IO ()
+shouldBeRightWrong len input = do
+    shouldBe (decode (encode input) :: Either PeekException i) (Right input)
+    shouldBe
+        (first
+             (const ())
+             (decode (encodeWrongPrefix len input) :: Either PeekException i))
+        (Left ())
+
+-- | Encode a thing with the wrong length prefix.
+encodeWrongPrefix :: Store thing => Int64 -> thing -> ByteString
+encodeWrongPrefix len thing = encode len <> encodeThingNoPrefix thing
+
+-- | Encode the thing and drop the length prefix.
+encodeThingNoPrefix :: Store thing => thing -> ByteString
+encodeThingNoPrefix = S.drop (S.length (encode (1 :: Int64))) . encode


### PR DESCRIPTION
So this PR is to explicitly have a module aimed at demonstrating Store's safety for consuming untrusted input. A client is considering Store and one of the concerns was:

> What if a vector comes in with a prefix-length of 1GB but the input is 4KB. Does Store (1) allocate, (2) attempt to access that much memory from the input (therefore a buffer overrun)?

I know from inspecting the code that @mgsloan already put checks in place in [peekToPlainForeignPtr](https://github.com/fpco/store/blob/8ee292c9702e0a425786ae56fbafd92697b390d5/store-core/src/Data/Store/Core.hs#L484..L496) and that in other areas Store generally does the Sane Thing, like how the bytestring package works on `Ptr`'s but does bounds checking so that its use is safe.

What remained for me, then, was to to contribute a test suite specifically addressing this concern, regardless of any other test suite.

@mgsloan Are you happy to merge this? Or can you also point out other areas of concern?