### PR TITLE
Fix and tests for mutable vector and hashmap

### DIFF
--- a/src/Data/Store/Internal.hs
+++ b/src/Data/Store/Internal.hs
@@ -315,15 +315,32 @@ pokeListLikeFoldable x = do
 -- function for initializing the sequence and a function for mutating an
 -- element at a particular index.
 peekMutableSequence
-    :: Store a
-    => (Int -> IO r)
+    :: forall a r. Store a
+    => String -- ^ type
+    -> (Int -> IO r)
     -> (r -> Int -> a -> IO ())
     -> Peek r
-peekMutableSequence new write = do
-    n <- peek
+peekMutableSequence ty new write = do
+    n :: Int <- peek
+    let minBufferSize :: Integer
+        minBufferSize =
+          case size :: Size a of
+            VarSize _ -> fromIntegral n -- minimum bound, assume 1 byte
+            ConstSize x -> fromIntegral n * fromIntegral x
+    remaining <-
+      Peek $ \ps sourcePtr ->
+      return $ PeekResult sourcePtr (peekStateEndPtr ps `minusPtr` sourcePtr)
+    when (minBufferSize > fromIntegral remaining) $
+      liftIO (tooManyBytes (fromIntegral minBufferSize) remaining ty)
+    case (size :: Size a) of
+      ConstSize 0 | n > maxNullaryVectorSize ->
+                    liftIO (throwIO $ PeekException remaining $ T.pack $
+                             "Max nullary vector size.")
+      _ -> return ()
     mut <- liftIO (new n)
     forM_ [0..n-1] $ \i -> peek >>= liftIO . write mut i
     return mut
+  where maxNullaryVectorSize = 4096
 {-# INLINE peekMutableSequence #-}
 
 ------------------------------------------------------------------------
@@ -360,7 +377,7 @@ isolate len m = Peek $ \ps ptr -> do
 instance Store a => Store (V.Vector a) where
     size = sizeSequence
     poke = pokeSequence
-    peek = V.unsafeFreeze =<< peekMutableSequence MV.new MV.write
+    peek = V.unsafeFreeze =<< peekMutableSequence "Data.Vector.Vector" MV.new MV.write
 
 instance Storable a => Store (SV.Vector a) where
     size = VarSize $ \x ->

--- a/src/Data/Store/Internal.hs
+++ b/src/Data/Store/Internal.hs
@@ -44,6 +44,7 @@ module Data.Store.Internal
     , sizeSequence, pokeSequence, peekSequence
     -- ** Store instances in terms of IsSet
     , sizeSet, pokeSet, peekSet
+    , markMapPokedInAscendingOrder
     -- ** Store instances in terms of IsMap
     , sizeMap, pokeMap, peekMap
     -- *** Utilities for ordered maps
@@ -68,7 +69,7 @@ module Data.Store.Internal
 import           Control.Applicative
 import           Control.DeepSeq (NFData)
 import           Control.Exception (throwIO)
-import           Control.Monad (when)
+import           Control.Monad (when, unless)
 import           Control.Monad.IO.Class (liftIO)
 import qualified Data.Array.Unboxed as A
 import qualified Data.ByteString as BS
@@ -279,15 +280,37 @@ pokeOrdMap x = poke markMapPokedInAscendingOrder >> pokeMap x
 -- | Decode the results of 'pokeOrdMap' using a given function to construct
 -- the map.
 peekOrdMapWith
-    :: (Store (ContainerKey t), Store (MapValue t))
+    :: (Ord (ContainerKey t), Store (ContainerKey t), Store (MapValue t))
     => ([(ContainerKey t, MapValue t)] -> t)
        -- ^ A function to construct the map from an ascending list such as
        -- 'Map.fromDistinctAscList'.
     -> Peek t
 peekOrdMapWith f = do
     peekMagic "ascending Map / IntMap" markMapPokedInAscendingOrder
-    f <$> peek
+    xs <- peek
+    remaining <-
+        Peek $ \ps sourcePtr ->
+            return $
+            PeekResult sourcePtr (peekStateEndPtr ps `minusPtr` sourcePtr)
+    unless
+        (ascending (map fst xs))
+        (liftIO
+             (throwIO
+                  (PeekException
+                       remaining
+                       "The keys in the input map are not ascending.")))
+    pure (f xs)
 {-# INLINE peekOrdMapWith #-}
+
+-- | Are all the values in the list ascending?
+ascending :: Ord a => [a] -> Bool
+ascending [] = True
+ascending (c:cs) = go c cs
+  where
+    go x (y:xs) =
+        (x < y) && go y xs
+    go _ [] = True
+{-# INLINE ascending #-}
 
 {-
 ------------------------------------------------------------------------

--- a/test/Data/Store/UntrustedSpec.hs
+++ b/test/Data/Store/UntrustedSpec.hs
@@ -50,13 +50,13 @@ spec =
                     it "Vector Int" (shouldBeRightWrong huge (V.fromList list))
                     it
                         "Vector Char"
-                        (shouldBeRightWrong huge (V.fromList sample))
+                        (shouldBeRightWrong huge (V.fromList (sample :: [Char])))
                     it
                         "Vector unit"
                         (shouldBeRightWrong
                              huge
                              (V.fromList (replicate 1000 ())))
-                    it "Seq Int" (shouldBeRightWrong huge (Seq.fromList sample)))
+                    it "Seq Int" (shouldBeRightWrong huge (Seq.fromList (sample :: [Char]))))
             describe
                 "Maps are consistent"
                 (do it

--- a/test/Data/Store/UntrustedSpec.hs
+++ b/test/Data/Store/UntrustedSpec.hs
@@ -39,12 +39,11 @@ spec =
                         (shouldBeRightWrong huge (sample :: L.ByteString))
                     it "Text" (shouldBeRightWrong huge (sample :: Text))
                     it "String" (shouldBeRightWrong huge (sample :: String))
-                    {- FIXME: These do too much allocation.
                     it "Vector Int" (shouldBeRightWrong huge (V.fromList list))
                     it
                         "Vector Char"
                         (shouldBeRightWrong huge (V.fromList sample))
-                    -}
+                    it "Vector unit" (shouldBeRightWrong huge (V.fromList (replicate 1000 ())))
                     it "Seq Int"
                         (shouldBeRightWrong huge (Seq.fromList sample)))
             describe
@@ -65,7 +64,8 @@ spec =
                              (Left ()))))
 
 huge :: Int64
-huge = 2^62
+huge = 2^(62::Int)
+
 
 -- | Check decode.encode==id and then check decode.badencode=>error.
 shouldBeRightWrong


### PR DESCRIPTION
@mgsloan Re our last PR #108 the following are implemented:

1. The approach you suggested for vectors to only allocate vector of n elements if at least n bytes are available as input.
2. On [here](https://github.com/fpco/store/compare/master...untrusted-peek-mutable#diff-9ead574b8096a8cfea1c3a95c0f964d1R366) I put a `maxNullaryVectorSize` at `4096` (arbitrary). We could perhaps put this as a compile-time flag. Any thoughts?
2. Added a check so that when consuming maps, it checks that the input list is ordered by key, rejects it otherwise.

There're tests for each of these.