### PR TITLE
Remove imports of Data.Typeable.Internal

### DIFF
--- a/src/Data/Store/Internal.hs
+++ b/src/Data/Store/Internal.hs
@@ -108,7 +108,7 @@ import qualified Data.Text.Array as TA
 import qualified Data.Text.Foreign as T
 import qualified Data.Text.Internal as T
 import qualified Data.Time as Time
-import           Data.Typeable.Internal (Typeable)
+import           Data.Typeable (Typeable)
 import qualified Data.Vector as V
 import qualified Data.Vector.Mutable as MV
 import qualified Data.Vector.Storable as SV

--- a/src/Data/Store/Version.hs
+++ b/src/Data/Store/Version.hs
@@ -44,7 +44,6 @@ import qualified Data.Text as T
 import           Data.Text.Encoding (encodeUtf8, decodeUtf8, decodeUtf8With)
 import           Data.Text.Encoding.Error (lenientDecode)
 import qualified Data.Text.IO as T
-import           Data.Typeable.Internal (TypeRep(..))
 import           Data.Word (Word32)
 import           GHC.Generics (Generic)
 import           Language.Haskell.TH
@@ -230,12 +229,9 @@ getStructureInfo' ignore renames _ = do
                 return (error "unexpected evaluation")
 
 showsQualTypeRep :: M.Map String String -> Int -> TypeRep -> ShowS
-#if MIN_VERSION_base(4,8,0)
-showsQualTypeRep renames p (TypeRep _ tycon _ tys) =
-#else
-showsQualTypeRep renames p (TypeRep _ tycon tys) =
-#endif
-    case tys of
+showsQualTypeRep renames p tyrep =
+  let (tycon, tys) = splitTyConApp tyrep
+  in case tys of
         [] -> showsQualTyCon renames tycon
         [x] | tycon == tcList -> showChar '[' . showsQualTypeRep renames 0 x . showChar ']'
           where


### PR DESCRIPTION
This module is removed from base in ghc-8.2. Luckily, it doesn't appear to have
been strictly necessary.

I'm depending on your CI to verify this works with versions earlier than 8.2