### PR TITLE
Revert untrusted safety

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,9 +2,6 @@
 
 ## Unreleased
 
-* Adds some protection against untrusted input using lots of
-  memory. See [#108](https://github.com/fpco/store/pull/108)
-
 ## 0.4.3.2
 
 * Buildable with GHC 8.2

--- a/src/Data/Store/Internal.hs
+++ b/src/Data/Store/Internal.hs
@@ -44,7 +44,6 @@ module Data.Store.Internal
     , sizeSequence, pokeSequence, peekSequence
     -- ** Store instances in terms of IsSet
     , sizeSet, pokeSet, peekSet
-    , markMapPokedInAscendingOrder
     -- ** Store instances in terms of IsMap
     , sizeMap, pokeMap, peekMap
     -- *** Utilities for ordered maps
@@ -69,7 +68,7 @@ module Data.Store.Internal
 import           Control.Applicative
 import           Control.DeepSeq (NFData)
 import           Control.Exception (throwIO)
-import           Control.Monad (when, unless)
+import           Control.Monad (when)
 import           Control.Monad.IO.Class (liftIO)
 import qualified Data.Array.Unboxed as A
 import qualified Data.ByteString as BS
@@ -282,37 +281,15 @@ pokeOrdMap x = poke markMapPokedInAscendingOrder >> pokeMap x
 -- | Decode the results of 'pokeOrdMap' using a given function to construct
 -- the map.
 peekOrdMapWith
-    :: (Ord (ContainerKey t), Store (ContainerKey t), Store (MapValue t))
+    :: (Store (ContainerKey t), Store (MapValue t))
     => ([(ContainerKey t, MapValue t)] -> t)
        -- ^ A function to construct the map from an ascending list such as
        -- 'Map.fromDistinctAscList'.
     -> Peek t
 peekOrdMapWith f = do
     peekMagic "ascending Map / IntMap" markMapPokedInAscendingOrder
-    xs <- peek
-    remaining <-
-        Peek $ \ps sourcePtr ->
-            return $
-            PeekResult sourcePtr (peekStateEndPtr ps `minusPtr` sourcePtr)
-    unless
-        (ascending (map fst xs))
-        (liftIO
-             (throwIO
-                  (PeekException
-                       remaining
-                       "The keys in the input map are not ascending.")))
-    pure (f xs)
+    f <$> peek
 {-# INLINE peekOrdMapWith #-}
-
--- | Are all the values in the list ascending?
-ascending :: Ord a => [a] -> Bool
-ascending [] = True
-ascending (c:cs) = go c cs
-  where
-    go x (y:xs) =
-        (x < y) && go y xs
-    go _ [] = True
-{-# INLINE ascending #-}
 
 {-
 ------------------------------------------------------------------------

--- a/test/Data/Store/UntrustedSpec.hs
+++ b/test/Data/Store/UntrustedSpec.hs
@@ -26,9 +26,13 @@ import           Data.Text (Text)
 import qualified Data.Vector as V
 import           Test.Hspec
 
--- | Test suite.
+-- FIXME: re-enable untrusted spec.
 spec :: Spec
-spec =
+spec = return ()
+
+-- | Test suite.
+actualSpec :: Spec
+actualSpec =
     describe
         "Untrusted input throws error"
         (do describe

--- a/test/Data/Store/UntrustedSpec.hs
+++ b/test/Data/Store/UntrustedSpec.hs
@@ -7,6 +7,13 @@
 
 module Data.Store.UntrustedSpec where
 
+import           Test.Hspec
+
+spec :: Spec
+spec = return ()
+
+{- Untrusted data spec is disabled for now.  See #122 / #123 for details
+
 import           Data.Bifunctor
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as S
@@ -24,11 +31,6 @@ import           Data.Store.Internal
 import           Data.String
 import           Data.Text (Text)
 import qualified Data.Vector as V
-import           Test.Hspec
-
--- FIXME: re-enable untrusted spec.
-spec :: Spec
-spec = return ()
 
 -- | Test suite.
 actualSpec :: Spec
@@ -180,3 +182,5 @@ instance Store DuplicatedMap where
               in take (length xs) (cycle (take 1 xs)))
     peek = error "DuplicatedMap.peek"
     size = VarSize (\(DuplicatedMap m) -> getSize m)
+
+-}


### PR DESCRIPTION
@chrisdone @snoyberg I do not think the changes for untrusted input solved the problem universally, and they added overhead in the case where you do trust the input.  I've opened https://github.com/fpco/store/issues/122 about a potential approach for supporting untrusted input.  It does not describe all the caveats of this variety of safety, there's quite a bit!

Main reason I am opening this PR is that the last release intentionally did not include these changes, and we may be gearing up for a new release due to https://github.com/fpco/store/pull/121 .  I'd rather not release partial safety for untrusted input, and do not like having an arbitrary size limit of 4096 for `Vector ()`