### PR TITLE
Remove criterion from testsuite dependencies

### DIFF
--- a/store.cabal
+++ b/store.cabal
@@ -208,7 +208,6 @@ test-suite store-weigh
     , bifunctors >=4.0
     , store
     , weigh
-    , criterion
     , cereal
     , cereal-vector
     , vector-binary-instances


### PR DESCRIPTION
Criterion is not used by the tests.