### PR TITLE
test: fix isThName filter for GHC 9.10+ (closes #182)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,17 @@
 # ChangeLog
 
+## Unreleased
+
+* Fix test compilation on GHC 9.10+, where `template-haskell` types
+  (`Type`, `TySynEqn`, `PkgName`, etc.) live in `GHC.Internal.TH.Syntax`
+  rather than `Language.Haskell.TH.Syntax`. The `isThName` filter that
+  skips TH AST types from the auto-generated `Store` roundtrip enumeration
+  was matching only the old module name and silently let the TH types
+  through, causing `No instance for 'Serial IO Type'` style errors.
+  See [#182][].
+
+[#182]: https://github.com/mgsloan/store/issues/182
+
 ## 0.7.20
 
 * Fixes build of test with `vector-0.13.2.0`. See [#181][].

--- a/test/Data/StoreSpec.hs
+++ b/test/Data/StoreSpec.hs
@@ -391,8 +391,16 @@ spec = do
              omitTys <- (omitTys0 ++) <$> mapM (\ty -> [t| PV.Vector $(pure ty) |]) omitTys0
              let f ty = isMonoType ty && ty `notElem` omitTys && null (listify isThName ty)
                  filtered = filter f insts
-                 -- Roundtrip testing of TH instances is disabled - see issue #150
-                 isThName n = nameModule n == Just "Language.Haskell.TH.Syntax"
+                 -- Roundtrip testing of TH instances is disabled - see issue #150.
+                 -- GHC 9.10+ ships template-haskell inside `ghc-internal`, so
+                 -- `nameModule` returns `GHC.Internal.TH.Syntax` for TH AST
+                 -- types (Type, TySynEqn, PkgName, SourceUnpackedness, ...).
+                 -- Match both module names so the filter keeps working on both
+                 -- old and new GHCs. See issue #182.
+                 isThName n = nameModule n `elem`
+                              [ Just "Language.Haskell.TH.Syntax"
+                              , Just "GHC.Internal.TH.Syntax"
+                              ]
              smallcheckManyStore verbose 2 $ map return filtered)
     it "Store on non-numeric Float/Double values" $ do
         let testNonNumeric :: forall a m. (RealFloat a, Eq a, Show a, Typeable a, Store a, Monad m, MonadFail m) => Proxy a -> m ()


### PR DESCRIPTION
GHC 9.10 moved `template-haskell` into the `ghc-internal` package. TH AST
type names like `Type`, `TySynEqn`, `PkgName`, `SourceUnpackedness` now
report `nameModule == Just "GHC.Internal.TH.Syntax"` instead of
`"Language.Haskell.TH.Syntax"`.

The `isThName` filter in `test/Data/StoreSpec.hs` (introduced for #150 to
skip TH AST types from the auto-generated `Store` roundtrip enumeration)
checks only against the old module path, so on GHC 9.10+ it silently lets
every TH type through. The TH splice then expands into property tests
like

```
changeDepth (\_ -> 2) $ \x -> checkRoundtrip False (x :: Type)
```

and fails to compile with `No instance for 'Serial IO Type'` (smallcheck
has no `Serial m` instance for these TH AST types). Reported in #182.

This PR matches both module names so the filter keeps working on the old
and new GHCs:

```haskell
isThName n = nameModule n `elem`
             [ Just "Language.Haskell.TH.Syntax"
             , Just "GHC.Internal.TH.Syntax"
             ]
```

I diagnosed this by adding a `Debug.Trace.trace` to `isThName` in a
nixpkgs build override and observing which module the offending names
came from.

Verified building `store-0.7.20` patched with this change against
`haskell.packages.ghc912` and `haskell.packages.ghc914` in nixpkgs
(both ship GHC > 9.10). Tests build and pass cleanly. The change is a
no-op on older GHCs that still place TH in `Language.Haskell.TH.Syntax`.

Closes #182.