### PR TITLE
test: gate CTimer on lookupTypeName, not base version

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+* Fix test compilation on platforms where libc lacks POSIX `timer_t`
+  (e.g. macOS), so `System.Posix.Types.CTimer` is not exported. The test
+  guarded `[t| CTimer |]` with `#if MIN_VERSION_base(4,10,0)`, but
+  `CTimer`'s availability is platform-dependent (gated on `HTYPE_TIMER_T`
+  by base's `configure`), not base-version-dependent. Use `lookupTypeName`
+  to detect the symbol at splice time.
+  See [#185][].
+
+[#185]: https://github.com/mgsloan/store/pull/185
+
+## 0.7.21
+
 * Fix test compilation on GHC 9.10+, where `template-haskell` types
   (`Type`, `TySynEqn`, `PkgName`, etc.) live in `GHC.Internal.TH.Syntax`
   rather than `Language.Haskell.TH.Syntax`. The `isThName` filter that

--- a/test/Data/StoreSpec.hs
+++ b/test/Data/StoreSpec.hs
@@ -345,6 +345,7 @@ spec :: Spec
 spec = do
     describe "Store on all monomorphic instances"
         $(do insts <- getAllInstanceTypes1 ''Store
+             ctimer <- maybe [] (pure . conT) <$> lookupTypeName "CTimer"
              omitTys0 <- sequence $
 #if !MIN_VERSION_primitive(0,7,0)
                  [t| Addr |] :
@@ -356,14 +357,13 @@ spec = do
                  , [t| TypeHash |]
                  , [t| Fd |]
                  , [t| NameFlavour |]
-#if MIN_VERSION_base(4,10,0)
-                 , [t| CTimer |]
-#endif
+                 ]
+              ++ ctimer
 
 -- Assume the TH generated instances for Time work, to avoid defining
 -- Serial instances. Also some lack Show / Eq.
 
-                 , [t| Time.AbsoluteTime |]
+              ++ [ [t| Time.AbsoluteTime |]
                  , [t| Time.Day |]
                  , [t| Time.LocalTime |]
                  , [t| Time.TimeOfDay |]


### PR DESCRIPTION
Fixes the build eg. on macOS. Probably affects other platforms as well